### PR TITLE
fix: Allow dots in tag suffix for versions like v10.9.4-custom-v1.8

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -33,11 +33,11 @@ jobs:
           
           # Pattern to match version tags like v10.9.4-custom-v1.8
           # Try to find tag in title first
-          TAG=$(echo "$PR_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_-]+)*' | head -1)
+          TAG=$(echo "$PR_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_.-]+)*' | head -1)
           
           # If not found in title, try body
           if [ -z "$TAG" ]; then
-            TAG=$(echo "$PR_BODY" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_-]+)*' | head -1)
+            TAG=$(echo "$PR_BODY" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_.-]+)*' | head -1)
           fi
           
           if [ -z "$TAG" ]; then


### PR DESCRIPTION
## Problem

The current regex pattern for extracting version tags from PR titles/body does not match dots in the suffix part. For example, `v10.9.4-custom-v1.8` was being matched as `v10.9.4-custom-v1`, truncating the `.8` part.

## Solution

Updated the regex pattern from `(-[a-zA-Z0-9_-]+)*` to `(-[a-zA-Z0-9_.-]+)*` to allow dots within the suffix portion of version tags.

## Test Result

Before this fix, the tag `v10.9.4-custom-v1.8` was extracted as `v10.9.4-custom-v1`.
After this fix, it should correctly extract as `v10.9.4-custom-v1.8`.

## Related

- Fixes the issue found during testing of the auto-tag-release workflow