### PR TITLE
Test release v10.9.5-custom-v2.0

### DIFF
--- a/TEST_AUTO_TAG.md
+++ b/TEST_AUTO_TAG.md
@@ -1,1 +1,2 @@
 Test commit for v10.9.4-custom-v1.8 tag automation
+Test commit for v10.9.5-custom-v2.0 tag automation (with dot fix)


### PR DESCRIPTION
This PR tests the auto-tag-release workflow with the regex fix. Expected tag: **v10.9.5-custom-v2.0** (should correctly extract the full version including dots in suffix)